### PR TITLE
set 3.10 as min python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,12 @@ readme = "README.md"
 authors = [
   { name = "Alexander Matthew Payne", email = "alex.payne@choderalab.org" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
We use the `match` syntax (which is great!) but requires python 3.10 or newer